### PR TITLE
feat(teams): implement team creation with validation and error handling

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/common/exception/DuplicateTeamException.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/exception/DuplicateTeamException.java
@@ -1,0 +1,14 @@
+package com.sportsevent.sportseventmanager.common.exception;
+
+public class DuplicateTeamException extends Exception {
+    private final int errorCode;
+
+    public DuplicateTeamException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/exception/InvalidDTOException.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/exception/InvalidDTOException.java
@@ -1,0 +1,14 @@
+package com.sportsevent.sportseventmanager.common.exception;
+
+public class InvalidDTOException extends Exception {
+    private final int errorCode;
+
+    public InvalidDTOException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/pagination/dto/PaginationDTO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/pagination/dto/PaginationDTO.java
@@ -1,0 +1,61 @@
+package com.sportsevent.sportseventmanager.common.pagination.dto;
+
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.validation.Validatable;
+
+public class PaginationDTO implements Validatable {
+    private Integer page;
+    private Integer size;
+
+    public PaginationDTO(Integer page, Integer size) {
+        this.page = page;
+        this.size = size;
+    }
+
+    public Integer getPage() {
+        return page;
+    }
+
+    public void setPage(Integer page) {
+        this.page = page;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    @Override
+    public String toString() {
+        return "PaginationDTO{" +
+                "page=" + page +
+                ", size=" + size +
+                '}';
+    }
+
+    @Override
+    public void validate() throws InvalidDTOException {
+        if (page == null) {
+            page = 1;
+        }
+
+        if (size == null) {
+            size = 10;
+        }
+
+        if (page < 1) {
+            throw new InvalidDTOException("page must be greater than 0", 400);
+        }
+
+        if (size < 1) {
+            throw new InvalidDTOException("size must be greater than 0", 400);
+        }
+
+        if (size > 100) {
+            throw new InvalidDTOException("size must be less than 100", 400);
+        }
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/response/ErrorResponse.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/response/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.sportsevent.sportseventmanager.common.response;
+
+public class ErrorResponse {
+    private String message;
+    private int errorCode;
+
+    public ErrorResponse(String message, int errorCode) {
+        this.message = message;
+        this.errorCode = errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(int errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/response/SuccessResponse.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/response/SuccessResponse.java
@@ -2,15 +2,25 @@ package com.sportsevent.sportseventmanager.common.response;
 
 import com.sportsevent.sportseventmanager.teams.model.Team;
 
+import java.util.List;
+
 public class SuccessResponse {
     private String message;
     private int status;
-    private Team data;
+    private List<Team> data;
+    private Long totalRecords;
+
+    public SuccessResponse(String message, int status, List<Team> data, Long totalRecords) {
+        this.message = message;
+        this.status = status;
+        this.data = data;
+        this.totalRecords = totalRecords;
+    }
 
     public SuccessResponse(String message, int status, Team data) {
         this.message = message;
         this.status = status;
-        this.data = data;
+        this.data = List.of(data);
     }
 
     public String getMessage() {
@@ -29,11 +39,19 @@ public class SuccessResponse {
         this.status = status;
     }
 
-    public Team getData() {
+    public List<Team> getData() {
         return data;
     }
 
-    public void setData(Team data) {
+    public void setData(List<Team> data) {
         this.data = data;
+    }
+
+    public Long getTotalRecords() {
+        return totalRecords;
+    }
+
+    public void setTotalRecords(Long totalRecords) {
+        this.totalRecords = totalRecords;
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/common/response/SuccessResponse.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/response/SuccessResponse.java
@@ -1,0 +1,39 @@
+package com.sportsevent.sportseventmanager.common.response;
+
+import com.sportsevent.sportseventmanager.teams.model.Team;
+
+public class SuccessResponse {
+    private String message;
+    private int status;
+    private Team data;
+
+    public SuccessResponse(String message, int status, Team data) {
+        this.message = message;
+        this.status = status;
+        this.data = data;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public Team getData() {
+        return data;
+    }
+
+    public void setData(Team data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/validation/DTOValidator.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/validation/DTOValidator.java
@@ -1,0 +1,9 @@
+package com.sportsevent.sportseventmanager.common.validation;
+
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+
+public class DTOValidator {
+    public static void validate(Validatable dto) throws InvalidDTOException {
+        dto.validate();
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/validation/Validatable.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/validation/Validatable.java
@@ -1,0 +1,7 @@
+package com.sportsevent.sportseventmanager.common.validation;
+
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+
+public interface Validatable {
+    void validate() throws InvalidDTOException;
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamRepository.java
@@ -1,11 +1,20 @@
 package com.sportsevent.sportseventmanager.teams;
 
 import com.sportsevent.sportseventmanager.teams.dao.TeamDAO;
+import com.sportsevent.sportseventmanager.teams.model.Team;
 
 public class TeamRepository {
-    private TeamDAO teamDAO;
+    private final TeamDAO teamDAO;
 
     public TeamRepository(TeamDAO teamDAO) {
         this.teamDAO = teamDAO;
+    }
+
+    public void addTeam(Team team) {
+        teamDAO.addTeam(team);
+    }
+
+    public boolean existsTeamByNameAndSport(String name, String sport) {
+        return teamDAO.existsTeamByNameAndSport(name, sport);
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamRepository.java
@@ -3,6 +3,8 @@ package com.sportsevent.sportseventmanager.teams;
 import com.sportsevent.sportseventmanager.teams.dao.TeamDAO;
 import com.sportsevent.sportseventmanager.teams.model.Team;
 
+import java.util.List;
+
 public class TeamRepository {
     private final TeamDAO teamDAO;
 
@@ -10,8 +12,16 @@ public class TeamRepository {
         this.teamDAO = teamDAO;
     }
 
+    public List<Team> getTeams(int page, int size) {
+        return teamDAO.getTeams(page, size);
+    }
+
     public void addTeam(Team team) {
         teamDAO.addTeam(team);
+    }
+
+    public long getTotalRecords() {
+        return teamDAO.getTotalRecords();
     }
 
     public boolean existsTeamByNameAndSport(String name, String sport) {

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamService.java
@@ -1,9 +1,27 @@
 package com.sportsevent.sportseventmanager.teams;
 
+import com.sportsevent.sportseventmanager.common.exception.DuplicateTeamException;
+import com.sportsevent.sportseventmanager.teams.dto.TeamDTO;
+import com.sportsevent.sportseventmanager.teams.model.Team;
+
 public class TeamService {
-    private TeamRepository teamRepository;
+    private final TeamRepository teamRepository;
 
     public TeamService(TeamRepository teamRepository) {
         this.teamRepository = teamRepository;
+    }
+
+    public Team addTeam(TeamDTO teamDTO) throws DuplicateTeamException {
+        Team team = new Team(
+                teamDTO.getName(), teamDTO.getSport(), teamDTO.getCity(), teamDTO.getFoundationDate(), teamDTO.getLogo()
+        );
+
+        if (teamRepository.existsTeamByNameAndSport(team.getName(), team.getSport())) {
+            throw new DuplicateTeamException("team with the same name and sport already exists", 409);
+        }
+
+        teamRepository.addTeam(team);
+
+        return team;
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamService.java
@@ -1,8 +1,12 @@
 package com.sportsevent.sportseventmanager.teams;
 
 import com.sportsevent.sportseventmanager.common.exception.DuplicateTeamException;
+import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
+import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.teams.dto.TeamDTO;
 import com.sportsevent.sportseventmanager.teams.model.Team;
+
+import java.util.List;
 
 public class TeamService {
     private final TeamRepository teamRepository;
@@ -11,7 +15,22 @@ public class TeamService {
         this.teamRepository = teamRepository;
     }
 
-    public Team addTeam(TeamDTO teamDTO) throws DuplicateTeamException {
+    public SuccessResponse getTeams(PaginationDTO paginationDTO) {
+        int page = paginationDTO.getPage();
+        int size = paginationDTO.getSize();
+
+        List<Team> teams = teamRepository.getTeams(page, size);
+        long totalRecords = teamRepository.getTotalRecords();
+
+        return new SuccessResponse(
+                "teams retrieved successfully",
+                200,
+                teams,
+                totalRecords
+        );
+    }
+
+    public SuccessResponse addTeam(TeamDTO teamDTO) throws DuplicateTeamException {
         Team team = new Team(
                 teamDTO.getName(), teamDTO.getSport(), teamDTO.getCity(), teamDTO.getFoundationDate(), teamDTO.getLogo()
         );
@@ -22,6 +41,10 @@ public class TeamService {
 
         teamRepository.addTeam(team);
 
-        return team;
+        return new SuccessResponse(
+                "team created successfully",
+                201,
+                team
+        );
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamServlet.java
@@ -3,12 +3,12 @@ package com.sportsevent.sportseventmanager.teams;
 import com.google.gson.Gson;
 import com.sportsevent.sportseventmanager.common.exception.DuplicateTeamException;
 import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.ErrorResponse;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.common.validation.DTOValidator;
 import com.sportsevent.sportseventmanager.teams.dao.TeamDAO;
 import com.sportsevent.sportseventmanager.teams.dto.TeamDTO;
-import com.sportsevent.sportseventmanager.teams.model.Team;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -32,19 +32,51 @@ public class TeamServlet extends HttpServlet {
     }
 
     @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String pageParam = req.getParameter("page");
+        String sizeParam = req.getParameter("size");
+
+        Integer page = (pageParam != null) ? Integer.parseInt(pageParam) : null;
+        Integer size = (sizeParam != null) ? Integer.parseInt(sizeParam) : null;
+
+        PaginationDTO paginationDTO = new PaginationDTO(page, size);
+
+        try {
+            DTOValidator.validate(paginationDTO);
+
+            SuccessResponse successResponse = teamService.getTeams(paginationDTO);
+
+            String jsonSuccessResponse = gson.toJson(successResponse);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonSuccessResponse);
+        } catch (InvalidDTOException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (Exception e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        }
+    }
+
+    @Override
     public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         TeamDTO teamDTO = gson.fromJson(req.getReader(), TeamDTO.class);
 
         try {
             DTOValidator.validate(teamDTO);
 
-            Team team = teamService.addTeam(teamDTO);
-
-            SuccessResponse successResponse = new SuccessResponse(
-                    "team created successfully",
-                    201,
-                    team
-            );
+            SuccessResponse successResponse = teamService.addTeam(teamDTO);
 
             String jsonSuccessResponse = gson.toJson(successResponse);
             resp.setContentType("application/json");

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamServlet.java
@@ -1,10 +1,21 @@
 package com.sportsevent.sportseventmanager.teams;
 
 import com.google.gson.Gson;
+import com.sportsevent.sportseventmanager.common.exception.DuplicateTeamException;
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.response.ErrorResponse;
+import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
+import com.sportsevent.sportseventmanager.common.validation.DTOValidator;
 import com.sportsevent.sportseventmanager.teams.dao.TeamDAO;
+import com.sportsevent.sportseventmanager.teams.dto.TeamDTO;
+import com.sportsevent.sportseventmanager.teams.model.Team;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 
 @WebServlet(name = "TeamServlet", urlPatterns = "/teams")
 public class TeamServlet extends HttpServlet {
@@ -18,5 +29,48 @@ public class TeamServlet extends HttpServlet {
         teamService = new TeamService(teamRepository);
 
         gson = new Gson();
+    }
+
+    @Override
+    public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        TeamDTO teamDTO = gson.fromJson(req.getReader(), TeamDTO.class);
+
+        try {
+            DTOValidator.validate(teamDTO);
+
+            Team team = teamService.addTeam(teamDTO);
+
+            SuccessResponse successResponse = new SuccessResponse(
+                    "team created successfully",
+                    201,
+                    team
+            );
+
+            String jsonSuccessResponse = gson.toJson(successResponse);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonSuccessResponse);
+        } catch (InvalidDTOException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.setContentType("application/json");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (DuplicateTeamException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_CONFLICT);
+            resp.setContentType("application/json");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (Exception e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.setContentType("application/json");
+            resp.getWriter().write(jsonErrorResponse);
+        }
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/dao/TeamDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/dao/TeamDAO.java
@@ -6,5 +6,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TeamDAO {
-    private List<Team> teams = new ArrayList<>();
+    private final List<Team> teams = new ArrayList<>();
+    private static int idCounter = 1;
+
+    public void addTeam(Team team) {
+        team.setId(idCounter++);
+        teams.addFirst(team);
+    }
+
+    public boolean existsTeamByNameAndSport(String teamName, String sport) {
+        for (Team team : teams) {
+            if (team.getName().equals(teamName) && team.getSport().equals(sport)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/dao/TeamDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/dao/TeamDAO.java
@@ -3,15 +3,31 @@ package com.sportsevent.sportseventmanager.teams.dao;
 import com.sportsevent.sportseventmanager.teams.model.Team;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TeamDAO {
     private final List<Team> teams = new ArrayList<>();
     private static int idCounter = 1;
 
+    public List<Team> getTeams(int page, int size) {
+        int fromIndex = (page - 1) * size;
+
+        if (fromIndex >= teams.size()) {
+            return Collections.emptyList();
+        }
+
+        int toIndex = Math.min(fromIndex + size, teams.size());
+        return teams.subList(fromIndex, toIndex);
+    }
+
     public void addTeam(Team team) {
         team.setId(idCounter++);
         teams.addFirst(team);
+    }
+
+    public long getTotalRecords() {
+        return teams.size();
     }
 
     public boolean existsTeamByNameAndSport(String teamName, String sport) {

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/dto/TeamDTO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/dto/TeamDTO.java
@@ -1,0 +1,94 @@
+package com.sportsevent.sportseventmanager.teams.dto;
+
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.validation.Validatable;
+
+public class TeamDTO implements Validatable {
+    private String name;
+    private String sport;
+    private String city;
+    private String foundationDate;
+    private String logo;
+
+    public TeamDTO(String name, String sport, String city, String foundationDate, String logo) {
+        this.name = name;
+        this.sport = sport;
+        this.city = city;
+        this.foundationDate = foundationDate;
+        this.logo = logo;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSport() {
+        return sport;
+    }
+
+    public void setSport(String sport) {
+        this.sport = sport;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    public String getFoundationDate() {
+        return foundationDate;
+    }
+
+    public void setFoundationDate(String foundationDate) {
+        this.foundationDate = foundationDate;
+    }
+
+    public String getLogo() {
+        return logo;
+    }
+
+    public void setLogo(String logo) {
+        this.logo = logo;
+    }
+
+    @Override
+    public String toString() {
+        return "TeamDTO{" +
+                "name='" + name + '\'' +
+                ", sport='" + sport + '\'' +
+                ", city='" + city + '\'' +
+                ", foundationDate='" + foundationDate + '\'' +
+                ", logo='" + logo + '\'' +
+                '}';
+    }
+
+    @Override
+    public void validate() throws InvalidDTOException {
+        if (name == null || name.trim().isEmpty()) {
+            throw new InvalidDTOException("team name is required", 400);
+        }
+
+        if (sport == null || sport.trim().isEmpty()) {
+            throw new InvalidDTOException("team sport is required", 400);
+        }
+
+        if (city == null || city.trim().isEmpty()) {
+            throw new InvalidDTOException("team city is required", 400);
+        }
+
+        if (foundationDate == null || foundationDate.trim().isEmpty()) {
+            throw new InvalidDTOException("team foundationDate is required", 400);
+        }
+
+        if (logo == null || logo.trim().isEmpty()) {
+            throw new InvalidDTOException("team logo is required", 400);
+        }
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/model/Team.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/model/Team.java
@@ -11,8 +11,7 @@ public class Team {
     private String logo;
     private ArrayList<Integer> players;
 
-    public Team(int id, String name, String sport, String city, String foundationDate, String logo) {
-        this.id = id;
+    public Team(String name, String sport, String city, String foundationDate, String logo) {
         this.name = name;
         this.sport = sport;
         this.city = city;


### PR DESCRIPTION
- Add `DTOValidator` to validate `TeamDTO` before creating a team.
- Implement `DuplicateTeamException` to handle duplicate team creation.
- Create `SuccessResponse` and `ErrorResponse` classes for JSON API responses.
- Modify `TeamDAO` to manage team IDs and prevent duplicates.
- Update `TeamService` and `TeamRepository` for team creation logic and validation.
- Refactor `TeamServlet` to handle POST requests and return appropriate success or error responses.