### PR TITLE
feat(config): centralize service initialization in ServiceConfig

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/config/ServiceConfig.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/config/ServiceConfig.java
@@ -1,0 +1,44 @@
+package com.sportsevent.sportseventmanager.config;
+
+import com.sportsevent.sportseventmanager.players.PlayerRepository;
+import com.sportsevent.sportseventmanager.players.PlayerService;
+import com.sportsevent.sportseventmanager.players.dao.PlayerDAO;
+import com.sportsevent.sportseventmanager.teams.TeamRepository;
+import com.sportsevent.sportseventmanager.teams.TeamService;
+import com.sportsevent.sportseventmanager.teams.dao.TeamDAO;
+
+public class ServiceConfig {
+    private static PlayerDAO playerDAO;
+    private static PlayerRepository playerRepository;
+    private static TeamDAO teamDAO;
+    private static TeamRepository teamRepository;
+    private static PlayerService playerService;
+    private static TeamService teamService;
+
+    static {
+        playerDAO = new PlayerDAO();
+        teamDAO = new TeamDAO();
+
+        playerRepository = new PlayerRepository(playerDAO);
+        teamRepository = new TeamRepository(teamDAO);
+
+        teamService = new TeamService(teamRepository);
+        playerService = new PlayerService(playerRepository, teamService);
+    }
+
+    public static PlayerService getPlayerService() {
+        return playerService;
+    }
+
+    public static TeamService getTeamService() {
+        return teamService;
+    }
+
+    public static PlayerDAO getPlayerDAO() {
+        return playerDAO;
+    }
+
+    public static TeamDAO getTeamDAO() {
+        return teamDAO;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/players/PlayerServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/players/PlayerServlet.java
@@ -2,6 +2,7 @@ package com.sportsevent.sportseventmanager.players;
 
 import com.google.gson.Gson;
 import com.sportsevent.sportseventmanager.players.dao.PlayerDAO;
+import com.sportsevent.sportseventmanager.config.ServiceConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -16,6 +17,7 @@ public class PlayerServlet extends HttpServlet {
         PlayerDAO playerDAO = new PlayerDAO();
         PlayerRepository playerRepository = new PlayerRepository(playerDAO);
         playerService = new PlayerService(playerRepository);
+        playerService = ServiceConfig.getPlayerService();
 
         gson = new Gson();
     }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamServlet.java
@@ -7,7 +7,7 @@ import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.ErrorResponse;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.common.validation.DTOValidator;
-import com.sportsevent.sportseventmanager.teams.dao.TeamDAO;
+import com.sportsevent.sportseventmanager.config.ServiceConfig;
 import com.sportsevent.sportseventmanager.teams.dto.TeamDTO;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -24,10 +24,7 @@ public class TeamServlet extends HttpServlet {
 
     @Override
     public void init() throws ServletException {
-        TeamDAO teamDAO = new TeamDAO();
-        TeamRepository teamRepository = new TeamRepository(teamDAO);
-        teamService = new TeamService(teamRepository);
-
+        teamService = ServiceConfig.getTeamService();
         gson = new Gson();
     }
 


### PR DESCRIPTION
- Moved service initialization to a centralized `ServiceConfig` class.
- Updated `TeamServlet` and `PlayerServlet` to use services from `ServiceConfig`.
- Simplified the `init()` method in `TeamServlet` and `PlayerServlet` by fetching services from `ServiceConfig`.