### PR TITLE
feat(gson): implement custom Gson provider and Instant adapter

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/common/adapters/InstantAdapter.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/adapters/InstantAdapter.java
@@ -1,0 +1,21 @@
+package com.sportsevent.sportseventmanager.common.adapters;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+public class InstantAdapter implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+
+    @Override
+    public Instant deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        return Instant.parse(jsonElement.getAsString());
+    }
+
+    @Override
+    public JsonElement serialize(Instant instant, Type type, JsonSerializationContext jsonSerializationContext) {
+        return new JsonPrimitive(formatter.format(instant));
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/utils/GsonProvider.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/utils/GsonProvider.java
@@ -1,0 +1,13 @@
+package com.sportsevent.sportseventmanager.common.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.sportsevent.sportseventmanager.common.adapters.InstantAdapter;
+
+import java.time.Instant;
+
+public class GsonProvider {
+    public static Gson createGson() {
+        return new GsonBuilder().registerTypeAdapter(Instant.class, new InstantAdapter()).create();
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/players/PlayerServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/players/PlayerServlet.java
@@ -2,6 +2,7 @@ package com.sportsevent.sportseventmanager.players;
 
 import com.google.gson.Gson;
 import com.sportsevent.sportseventmanager.players.dao.PlayerDAO;
+import com.sportsevent.sportseventmanager.common.utils.GsonProvider;
 import com.sportsevent.sportseventmanager.config.ServiceConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -18,6 +19,8 @@ public class PlayerServlet extends HttpServlet {
         PlayerRepository playerRepository = new PlayerRepository(playerDAO);
         playerService = new PlayerService(playerRepository);
         playerService = ServiceConfig.getPlayerService();
+        gson = GsonProvider.createGson();
+    }
 
         gson = new Gson();
     }


### PR DESCRIPTION
- Add `GsonProvider.createGson()` to provide a configured Gson instance.
- Implement `InstantAdapter` to handle custom serialization and deserialization of `Instant` objects.
- Refactor `PlayerServlet` and `TeamServlet` to use `ServiceConfig` for service injection.
- Replace manual Gson instantiation with `GsonProvider.createGson()` for cleaner initialization.