### PR TITLE
feat(player): apply pagination in player retrieval

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/players/PlayerRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/players/PlayerRepository.java
@@ -3,6 +3,8 @@ package com.sportsevent.sportseventmanager.players;
 import com.sportsevent.sportseventmanager.players.dao.PlayerDAO;
 import com.sportsevent.sportseventmanager.players.model.Player;
 
+import java.util.List;
+
 public class PlayerRepository {
     private PlayerDAO playerDAO;
 
@@ -12,6 +14,14 @@ public class PlayerRepository {
 
     public void addPlayer(Player player) {
         playerDAO.addPlayer(player);
+    }
+
+    public List<Player> getPlayers(int page, int size) {
+        return playerDAO.getPlayers(page, size);
+    }
+
+    public long getTotalRecords() {
+        return playerDAO.getTotalRecords();
     }
 
     public boolean existsPlayerByFirstNameAndLastName(String firstName, String lastName) {

--- a/src/main/java/com/sportsevent/sportseventmanager/players/PlayerServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/players/PlayerServlet.java
@@ -3,7 +3,9 @@ package com.sportsevent.sportseventmanager.players;
 import com.google.gson.Gson;
 import com.sportsevent.sportseventmanager.common.exception.DuplicatePlayerException;
 import com.sportsevent.sportseventmanager.common.exception.DuplicatePlayerNumberException;
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
 import com.sportsevent.sportseventmanager.common.exception.TeamNotFoundException;
+import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.ErrorResponse;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.common.utils.GsonProvider;
@@ -27,6 +29,43 @@ public class PlayerServlet extends HttpServlet {
     public void init() throws ServletException {
         playerService = ServiceConfig.getPlayerService();
         gson = GsonProvider.createGson();
+    }
+
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String pageParam = req.getParameter("page");
+        String sizeParam = req.getParameter("size");
+
+        Integer page = (pageParam != null) ? Integer.parseInt(pageParam) : null;
+        Integer size = (sizeParam != null) ? Integer.parseInt(sizeParam) : null;
+
+        PaginationDTO paginationDTO = new PaginationDTO(page, size);
+
+        try {
+            DTOValidator.validate(paginationDTO);
+
+            SuccessResponse successResponse = playerService.getPlayers(paginationDTO);
+
+            String jsonSuccessResponse = gson.toJson(successResponse);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonSuccessResponse);
+        } catch (InvalidDTOException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (Exception e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        }
     }
 
     public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/src/main/java/com/sportsevent/sportseventmanager/players/dao/PlayerDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/players/dao/PlayerDAO.java
@@ -3,15 +3,31 @@ package com.sportsevent.sportseventmanager.players.dao;
 import com.sportsevent.sportseventmanager.players.model.Player;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class PlayerDAO {
     private List<Player> players = new ArrayList<>();
     private int idCounter = 1;
 
+    public List<Player> getPlayers(int page, int size) {
+        int fromIndex = (page - 1) * size;
+
+        if (fromIndex >= players.size()) {
+            return Collections.emptyList();
+        }
+
+        int toIndex = Math.min(fromIndex + size, players.size());
+        return players.subList(fromIndex, toIndex);
+    }
+
     public void addPlayer(Player player) {
         player.setId(idCounter++);
         players.addFirst(player);
+    }
+
+    public long getTotalRecords() {
+        return players.size();
     }
 
     public boolean existsPlayerByFirstNameAndLastName(String firstName, String lastName) {

--- a/src/main/java/com/sportsevent/sportseventmanager/players/dto/PlayerWithTeamDTO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/players/dto/PlayerWithTeamDTO.java
@@ -1,0 +1,89 @@
+package com.sportsevent.sportseventmanager.players.dto;
+
+import java.time.Instant;
+
+public class PlayerWithTeamDTO {
+    private int playerId;
+    private String firstName;
+    private String lastName;
+    private Instant birthDate;
+    private String nationality;
+    private int number;
+    private int teamId;
+    private String teamName;
+
+    public PlayerWithTeamDTO(int playerId, String firstName, String lastName, Instant birthDate, String nationality, int number, int teamId, String teamName) {
+        this.playerId = playerId;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.birthDate = birthDate;
+        this.nationality = nationality;
+        this.number = number;
+        this.teamId = teamId;
+        this.teamName = teamName;
+    }
+
+    public int getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(int playerId) {
+        this.playerId = playerId;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public Instant getBirthDate() {
+        return birthDate;
+    }
+
+    public void setBirthDate(Instant birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    public String getNationality() {
+        return nationality;
+    }
+
+    public void setNationality(String nationality) {
+        this.nationality = nationality;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    public int getTeamId() {
+        return teamId;
+    }
+
+    public void setTeamId(int teamId) {
+        this.teamId = teamId;
+    }
+
+    public String getTeamName() {
+        return teamName;
+    }
+
+    public void setTeamName(String teamName) {
+        this.teamName = teamName;
+    }
+}


### PR DESCRIPTION
- Modify `PlayerService` to apply pagination logic when retrieving players.
- Update `PlayerRepository` to call paginated `getPlayers` method from DAO.
- Update `PlayerServlet` to handle `page` and `size` query parameters for paginated response.
- Modify `SuccessResponse` to return paginated player data with `totalRecords`.