### PR TITLE
feat(events): implement pagination for event retrieval

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
@@ -3,11 +3,21 @@ package com.sportsevent.sportseventmanager.events;
 import com.sportsevent.sportseventmanager.events.dao.EventDAO;
 import com.sportsevent.sportseventmanager.events.model.Event;
 
+import java.util.List;
+
 public class EventRepository {
     EventDAO eventDAO;
 
     public EventRepository(EventDAO eventDAO) {
         this.eventDAO = eventDAO;
+    }
+
+    public List<Event> getEvents(int page, int size) {
+        return eventDAO.getEvents(page, size);
+    }
+
+    public long getTotalRecords() {
+        return eventDAO.getTotalRecords();
     }
 
     public boolean existsEventByNameAndSport(String eventName, String sport) {

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
@@ -1,15 +1,33 @@
 package com.sportsevent.sportseventmanager.events;
 
 import com.sportsevent.sportseventmanager.common.exception.DuplicateEventException;
+import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.events.dto.EventDTO;
 import com.sportsevent.sportseventmanager.events.model.Event;
+
+import java.util.List;
 
 public class EventService {
     EventRepository eventRepository;
 
     public EventService(EventRepository eventRepository) {
         this.eventRepository = eventRepository;
+    }
+
+    public SuccessResponse getEvents(PaginationDTO paginationDTO) {
+        int page = paginationDTO.getPage();
+        int size = paginationDTO.getSize();
+
+        List<Event> events = eventRepository.getEvents(page, size);
+        long totalRecords = eventRepository.getTotalRecords();
+
+        return new SuccessResponse(
+                "events retrieved successfully",
+                200,
+                events,
+                totalRecords
+        );
     }
 
     public SuccessResponse addEvent(EventDTO eventDTO) throws DuplicateEventException {

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventServlet.java
@@ -3,6 +3,7 @@ package com.sportsevent.sportseventmanager.events;
 import com.google.gson.Gson;
 import com.sportsevent.sportseventmanager.common.exception.DuplicateEventException;
 import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.ErrorResponse;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.common.utils.GsonProvider;
@@ -28,6 +29,43 @@ public class EventServlet extends HttpServlet {
         gson = GsonProvider.createGson();
     }
 
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String pageParam = req.getParameter("page");
+        String sizeParam = req.getParameter("size");
+
+        Integer page = (pageParam != null) ? Integer.parseInt(pageParam) : null;
+        Integer size = (sizeParam != null) ? Integer.parseInt(sizeParam) : null;
+
+        PaginationDTO paginationDTO = new PaginationDTO(page, size);
+
+        try {
+            DTOValidator.validate(paginationDTO);
+
+            SuccessResponse successResponse = eventService.getEvents(paginationDTO);
+
+            String jsonSuccessResponse = gson.toJson(successResponse);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonSuccessResponse);
+        } catch (InvalidDTOException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (Exception e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        }
+    }
 
     @Override
     public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
@@ -3,11 +3,27 @@ package com.sportsevent.sportseventmanager.events.dao;
 import com.sportsevent.sportseventmanager.events.model.Event;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class EventDAO {
     List<Event> events = new ArrayList<>();
     private static int idCounter = 1;
+
+    public List<Event> getEvents(int page, int size) {
+        int fromIndex = (page - 1) * size;
+
+        if (fromIndex >= events.size()) {
+            return Collections.emptyList();
+        }
+
+        int toIndex = Math.min(fromIndex + size, events.size());
+        return events.subList(fromIndex, toIndex);
+    }
+
+    public long getTotalRecords() {
+        return events.size();
+    }
 
     public void addEvent(Event event) {
         event.setId(idCounter++);


### PR DESCRIPTION
- Add pagination logic in `EventServlet` to handle `page` and `size` query parameters.
- Update `EventService` to return paginated results with `totalRecords`.
- Modify `EventRepository` and `EventDAO` to support pagination in fetching events.
- Ensure `SuccessResponse` includes pagination data for event retrieval.