### PR TITLE
feat(events): add functionality to add team to event

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/common/exception/EventNotFoundException.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/exception/EventNotFoundException.java
@@ -1,0 +1,14 @@
+package com.sportsevent.sportseventmanager.common.exception;
+
+public class EventNotFoundException extends Exception {
+    private final int errorCode;
+
+    public EventNotFoundException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/common/exception/TeamAlreadyAddedException.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/exception/TeamAlreadyAddedException.java
@@ -1,0 +1,14 @@
+package com.sportsevent.sportseventmanager.common.exception;
+
+public class TeamAlreadyAddedException extends Exception {
+    private final int errorCode;
+
+    public TeamAlreadyAddedException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/config/ServiceConfig.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/config/ServiceConfig.java
@@ -32,7 +32,7 @@ public class ServiceConfig {
 
         teamService = new TeamService(teamRepository);
         playerService = new PlayerService(playerRepository, teamService);
-        eventService = new EventService(eventRepository);
+        eventService = new EventService(eventRepository, teamService);
     }
 
     public static PlayerService getPlayerService() {
@@ -54,7 +54,7 @@ public class ServiceConfig {
     public static TeamDAO getTeamDAO() {
         return teamDAO;
     }
-    
+
     public static EventDAO getEventDAO() {
         return eventDAO;
     }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
@@ -16,6 +16,10 @@ public class EventRepository {
         return eventDAO.getEvents(page, size);
     }
 
+    public Event getEventById(int id) {
+        return eventDAO.getEventById(id);
+    }
+
     public long getTotalRecords() {
         return eventDAO.getTotalRecords();
     }
@@ -24,7 +28,15 @@ public class EventRepository {
         return eventDAO.existsEventByNameAndSport(eventName, sport);
     }
 
+    public boolean isTeamAlreadyAddedToEvent(int eventId, int teamId) {
+        return eventDAO.isTeamAlreadyAddedToEvent(eventId, teamId);
+    }
+
     public void addEvent(Event event) {
         eventDAO.addEvent(event);
+    }
+
+    public void addTeamToEvent(int teamId, int eventId) {
+        eventDAO.addTeamToEvent(teamId, eventId);
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
@@ -1,18 +1,25 @@
 package com.sportsevent.sportseventmanager.events;
 
 import com.sportsevent.sportseventmanager.common.exception.DuplicateEventException;
+import com.sportsevent.sportseventmanager.common.exception.EventNotFoundException;
+import com.sportsevent.sportseventmanager.common.exception.TeamAlreadyAddedException;
+import com.sportsevent.sportseventmanager.common.exception.TeamNotFoundException;
 import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
+import com.sportsevent.sportseventmanager.events.dto.AddTeamToEventDTO;
 import com.sportsevent.sportseventmanager.events.dto.EventDTO;
 import com.sportsevent.sportseventmanager.events.model.Event;
+import com.sportsevent.sportseventmanager.teams.TeamService;
 
 import java.util.List;
 
 public class EventService {
     EventRepository eventRepository;
+    TeamService teamService;
 
-    public EventService(EventRepository eventRepository) {
+    public EventService(EventRepository eventRepository, TeamService teamService) {
         this.eventRepository = eventRepository;
+        this.teamService = teamService;
     }
 
     public SuccessResponse getEvents(PaginationDTO paginationDTO) {
@@ -48,6 +55,28 @@ public class EventService {
         return new SuccessResponse(
                 "event created successfully",
                 201,
+                event
+        );
+    }
+
+    public SuccessResponse addTeamToEvent(AddTeamToEventDTO addTeamToEventDTO) throws EventNotFoundException, TeamAlreadyAddedException, TeamNotFoundException {
+        Event event = eventRepository.getEventById(addTeamToEventDTO.getEventId());
+
+        if (event == null) {
+            throw new EventNotFoundException("event not found", 404);
+        }
+
+        if (eventRepository.isTeamAlreadyAddedToEvent(addTeamToEventDTO.getEventId(), addTeamToEventDTO.getTeamId())) {
+            throw new TeamAlreadyAddedException("team already added", 409);
+        }
+
+        teamService.getTeamById(addTeamToEventDTO.getTeamId());
+        
+        eventRepository.addTeamToEvent(addTeamToEventDTO.getEventId(), addTeamToEventDTO.getTeamId());
+
+        return new SuccessResponse(
+                "team added to event successfully",
+                200,
                 event
         );
     }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventServlet.java
@@ -1,14 +1,14 @@
 package com.sportsevent.sportseventmanager.events;
 
 import com.google.gson.Gson;
-import com.sportsevent.sportseventmanager.common.exception.DuplicateEventException;
-import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.exception.*;
 import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.ErrorResponse;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.common.utils.GsonProvider;
 import com.sportsevent.sportseventmanager.common.validation.DTOValidator;
 import com.sportsevent.sportseventmanager.config.ServiceConfig;
+import com.sportsevent.sportseventmanager.events.dto.AddTeamToEventDTO;
 import com.sportsevent.sportseventmanager.events.dto.EventDTO;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -92,6 +92,57 @@ public class EventServlet extends HttpServlet {
             String jsonErrorResponse = gson.toJson(errorResponse);
 
             resp.setStatus(HttpServletResponse.SC_CONFLICT);
+            resp.setContentType("application/json");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (Exception e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.setContentType("application/json");
+            resp.getWriter().write(jsonErrorResponse);
+        }
+    }
+
+    @Override
+    public void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        AddTeamToEventDTO addTeamToEventDTO = gson.fromJson(req.getReader(), AddTeamToEventDTO.class);
+
+        try {
+            DTOValidator.validate(addTeamToEventDTO);
+
+            SuccessResponse successResponse = eventService.addTeamToEvent(addTeamToEventDTO);
+
+            String jsonSuccessResponse = gson.toJson(successResponse);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonSuccessResponse);
+        } catch (TeamNotFoundException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+
+            String jsonErrorResponse = gson.toJson(errorResponse);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (InvalidDTOException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.setContentType("application/json");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (EventNotFoundException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            resp.setContentType("application/json");
+            resp.getWriter().write(jsonErrorResponse);
+        } catch (TeamAlreadyAddedException e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             resp.setContentType("application/json");
             resp.getWriter().write(jsonErrorResponse);
         } catch (Exception e) {

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
@@ -21,6 +21,15 @@ public class EventDAO {
         return events.subList(fromIndex, toIndex);
     }
 
+    public Event getEventById(int eventId) {
+        for (Event event : events) {
+            if (event.getId() == eventId) {
+                return event;
+            }
+        }
+        return null;
+    }
+
     public long getTotalRecords() {
         return events.size();
     }
@@ -30,10 +39,26 @@ public class EventDAO {
         events.add(event);
     }
 
+    public void addTeamToEvent(int eventId, int teamId) {
+        Event event = getEventById(eventId);
+        if (event != null) {
+            event.addParticipatingTeam(teamId);
+        }
+    }
+
     public boolean existsEventByNameAndSport(String eventName, String sport) {
         for (Event event : events) {
             if (event.getName().equals(eventName) && event.getSport().equals(sport)) {
                 return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isTeamAlreadyAddedToEvent(int eventId, int teamId) {
+        for (Event event : events) {
+            if (event.getId() == eventId) {
+                return event.getParticipatingTeams().contains(teamId);
             }
         }
         return false;

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dto/AddTeamToEventDTO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dto/AddTeamToEventDTO.java
@@ -1,0 +1,41 @@
+package com.sportsevent.sportseventmanager.events.dto;
+
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.validation.Validatable;
+
+public class AddTeamToEventDTO implements Validatable {
+    private Integer eventId;
+    private Integer teamId;
+
+    public AddTeamToEventDTO(Integer eventId, Integer teamId) {
+        this.eventId = eventId;
+        this.teamId = teamId;
+    }
+
+    public Integer getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Integer eventId) {
+        this.eventId = eventId;
+    }
+
+    public Integer getTeamId() {
+        return teamId;
+    }
+
+    public void setTeamId(Integer teamId) {
+        this.teamId = teamId;
+    }
+
+    @Override
+    public void validate() throws InvalidDTOException {
+        if (eventId == null || eventId <= 0) {
+            throw new InvalidDTOException("eventId is required", 400);
+        }
+
+        if (teamId == null || teamId <= 0) {
+            throw new InvalidDTOException("teamId is required", 400);
+        }
+    }
+}


### PR DESCRIPTION
- Implement `addTeamToEvent` endpoint in `EventServlet` for adding a team to an event.
- Add `AddTeamToEventDTO` to capture necessary data for adding teams.
- Handle exceptions for `TeamAlreadyAddedException`, `EventNotFoundException`, and `TeamNotFoundException`.
- Update `EventService` to manage team addition logic, including checking for duplicate teams and invalid event IDs.
- Modify `EventRepository` and `EventDAO` to handle adding teams to events and validating team membership.