### PR TITLE
feat(events): update event status when adding teams

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
@@ -39,4 +39,8 @@ public class EventRepository {
     public void addTeamToEvent(int teamId, int eventId) {
         eventDAO.addTeamToEvent(teamId, eventId);
     }
+
+    public void updateStatusEvent(int eventId, String status) {
+        eventDAO.updateStatusEvent(eventId, status);
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
@@ -71,8 +71,12 @@ public class EventService {
         }
 
         teamService.getTeamById(addTeamToEventDTO.getTeamId());
-        
+
         eventRepository.addTeamToEvent(addTeamToEventDTO.getEventId(), addTeamToEventDTO.getTeamId());
+
+        if (event.getParticipatingTeams().size() >= 2) {
+            eventRepository.updateStatusEvent(addTeamToEventDTO.getEventId(), "En Progreso");
+        }
 
         return new SuccessResponse(
                 "team added to event successfully",

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
@@ -46,6 +46,14 @@ public class EventDAO {
         }
     }
 
+    public void updateStatusEvent(int eventId, String status) {
+        Event event = getEventById(eventId);
+
+        if (event != null) {
+            event.setStatus(status);
+        }
+    }
+
     public boolean existsEventByNameAndSport(String eventName, String sport) {
         for (Event event : events) {
             if (event.getName().equals(eventName) && event.getSport().equals(sport)) {


### PR DESCRIPTION
- Add logic in `EventService` to update event status to "En Progreso" once 2 or more teams are added.
- Implement `updateStatusEvent` method in `EventRepository` to delegate the status update to the DAO.
- Modify `EventDAO` to update the event's status based on the event ID.