### PR TITLE
feat(events): add event status update functionality

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/common/exception/InvalidEventStatusException.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/exception/InvalidEventStatusException.java
@@ -1,0 +1,14 @@
+package com.sportsevent.sportseventmanager.common.exception;
+
+public class InvalidEventStatusException extends Exception {
+    private int errorCode;
+
+    public InvalidEventStatusException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
@@ -1,9 +1,6 @@
 package com.sportsevent.sportseventmanager.events;
 
-import com.sportsevent.sportseventmanager.common.exception.DuplicateEventException;
-import com.sportsevent.sportseventmanager.common.exception.EventNotFoundException;
-import com.sportsevent.sportseventmanager.common.exception.TeamAlreadyAddedException;
-import com.sportsevent.sportseventmanager.common.exception.TeamNotFoundException;
+import com.sportsevent.sportseventmanager.common.exception.*;
 import com.sportsevent.sportseventmanager.common.pagination.dto.PaginationDTO;
 import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.events.dto.AddTeamToEventDTO;
@@ -111,6 +108,26 @@ public class EventService {
 
         return new SuccessResponse(
                 "team added to event successfully",
+                200,
+                event
+        );
+    }
+
+    public SuccessResponse updateEventStatus(int eventId, String status) throws EventNotFoundException, InvalidEventStatusException {
+        Event event = eventRepository.getEventById(eventId);
+
+        if (event == null) {
+            throw new EventNotFoundException("event not found", 404);
+        }
+
+        if ("En Progreso".equals(status) && event.getParticipatingTeams().size() < 2) {
+            throw new InvalidEventStatusException("cannot start the event with less than 2 teams", 400);
+        }
+
+        eventRepository.updateStatusEvent(eventId, status);
+
+        return new SuccessResponse(
+                "event status updated successfully",
                 200,
                 event
         );

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventServlet.java
@@ -9,6 +9,7 @@ import com.sportsevent.sportseventmanager.common.utils.GsonProvider;
 import com.sportsevent.sportseventmanager.common.validation.DTOValidator;
 import com.sportsevent.sportseventmanager.config.ServiceConfig;
 import com.sportsevent.sportseventmanager.events.dto.AddTeamToEventDTO;
+import com.sportsevent.sportseventmanager.events.dto.ChangeEventStatusDTO;
 import com.sportsevent.sportseventmanager.events.dto.EventDTO;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -18,7 +19,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
-@WebServlet(name = "EventServlet", urlPatterns = "/events")
+@WebServlet(name = "EventServlet", urlPatterns = "/events/*")
 public class EventServlet extends HttpServlet {
     EventService eventService;
     Gson gson;
@@ -106,52 +107,113 @@ public class EventServlet extends HttpServlet {
 
     @Override
     public void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        AddTeamToEventDTO addTeamToEventDTO = gson.fromJson(req.getReader(), AddTeamToEventDTO.class);
+        String pathInfo = req.getPathInfo();
 
-        try {
-            DTOValidator.validate(addTeamToEventDTO);
+        if (pathInfo == null || pathInfo.equals("/")) {
 
-            SuccessResponse successResponse = eventService.addTeamToEvent(addTeamToEventDTO);
+            AddTeamToEventDTO addTeamToEventDTO = gson.fromJson(req.getReader(), AddTeamToEventDTO.class);
 
-            String jsonSuccessResponse = gson.toJson(successResponse);
-            resp.setContentType("application/json");
-            resp.setCharacterEncoding("UTF-8");
-            resp.getWriter().write(jsonSuccessResponse);
-        } catch (TeamNotFoundException e) {
-            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+            try {
+                DTOValidator.validate(addTeamToEventDTO);
 
-            String jsonErrorResponse = gson.toJson(errorResponse);
-            resp.setContentType("application/json");
-            resp.setCharacterEncoding("UTF-8");
-            resp.getWriter().write(jsonErrorResponse);
-        } catch (InvalidDTOException e) {
-            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
-            String jsonErrorResponse = gson.toJson(errorResponse);
+                SuccessResponse successResponse = eventService.addTeamToEvent(addTeamToEventDTO);
 
-            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            resp.setContentType("application/json");
-            resp.getWriter().write(jsonErrorResponse);
-        } catch (EventNotFoundException e) {
-            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
-            String jsonErrorResponse = gson.toJson(errorResponse);
+                String jsonSuccessResponse = gson.toJson(successResponse);
+                resp.setContentType("application/json");
+                resp.setCharacterEncoding("UTF-8");
+                resp.getWriter().write(jsonSuccessResponse);
+            } catch (TeamNotFoundException e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
 
-            resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            resp.setContentType("application/json");
-            resp.getWriter().write(jsonErrorResponse);
-        } catch (TeamAlreadyAddedException e) {
-            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
-            String jsonErrorResponse = gson.toJson(errorResponse);
+                String jsonErrorResponse = gson.toJson(errorResponse);
+                resp.setContentType("application/json");
+                resp.setCharacterEncoding("UTF-8");
+                resp.getWriter().write(jsonErrorResponse);
+            } catch (InvalidDTOException e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+                String jsonErrorResponse = gson.toJson(errorResponse);
 
-            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            resp.setContentType("application/json");
-            resp.getWriter().write(jsonErrorResponse);
-        } catch (Exception e) {
-            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
-            String jsonErrorResponse = gson.toJson(errorResponse);
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            } catch (EventNotFoundException e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+                String jsonErrorResponse = gson.toJson(errorResponse);
 
-            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            resp.setContentType("application/json");
-            resp.getWriter().write(jsonErrorResponse);
+                resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            } catch (TeamAlreadyAddedException e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+                String jsonErrorResponse = gson.toJson(errorResponse);
+
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            } catch (Exception e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+                String jsonErrorResponse = gson.toJson(errorResponse);
+
+                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            }
+        } else if (pathInfo.matches("/\\d+/status")) {
+            String[] pathParts = pathInfo.split("/");
+
+            if (pathParts.length != 3) {
+                ErrorResponse errorResponse = new ErrorResponse("invalid path parameters", 500);
+                String jsonErrorResponse = gson.toJson(errorResponse);
+
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                resp.setContentType("application/json");
+                resp.setCharacterEncoding("UTF-8");
+                resp.getWriter().write(jsonErrorResponse);
+            }
+
+            int eventId = Integer.parseInt(pathParts[1]);
+
+            ChangeEventStatusDTO changeEventStatusDTO = gson.fromJson(req.getReader(), ChangeEventStatusDTO.class);
+
+
+            try {
+                DTOValidator.validate(changeEventStatusDTO);
+
+                SuccessResponse successResponse = eventService.updateEventStatus(eventId, changeEventStatusDTO.getStatus());
+                String jsonSuccessResponse = gson.toJson(successResponse);
+
+                resp.setContentType("application/json");
+                resp.setCharacterEncoding("UTF-8");
+                resp.getWriter().write(jsonSuccessResponse);
+            } catch (InvalidDTOException e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+                String jsonErrorResponse = gson.toJson(errorResponse);
+
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            } catch (EventNotFoundException e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+                String jsonErrorResponse = gson.toJson(errorResponse);
+
+                resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            } catch (InvalidEventStatusException e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), e.getErrorCode());
+                String jsonErrorResponse = gson.toJson(errorResponse);
+
+                resp.setStatus(HttpServletResponse.SC_CONFLICT);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            } catch (Exception e) {
+                ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+                String jsonErrorResponse = gson.toJson(errorResponse);
+
+                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                resp.setContentType("application/json");
+                resp.getWriter().write(jsonErrorResponse);
+            }
         }
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dto/ChangeEventStatusDTO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dto/ChangeEventStatusDTO.java
@@ -1,0 +1,31 @@
+package com.sportsevent.sportseventmanager.events.dto;
+
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.validation.Validatable;
+
+public class ChangeEventStatusDTO implements Validatable {
+    private String status;
+
+    public ChangeEventStatusDTO(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @Override
+    public void validate() throws InvalidDTOException {
+        if (status == null) {
+            throw new InvalidDTOException("status is required", 400);
+        }
+
+        if (!status.equals("Programado") && !status.equals("En Progreso") && !status.equals("Finalizado") && !status.equals("Cancelado")) {
+            throw new InvalidDTOException("status should be \"Programado\" or \"En Progreso\" or \"Finalizado\" or \"Cancelado\"", 400);
+        }
+    }
+}


### PR DESCRIPTION
- Added a new method `updateEventStatus` in `EventService` to handle status updates for events.
- Implemented validation to ensure that events cannot start with less than 2 participating teams.
- Updated `EventServlet` to handle the `/events/{eventId}/status` endpoint for changing the event status.
- Introduced `ChangeEventStatusDTO` to capture the status change request from the user.
- Enhanced error handling for invalid paths, event not found, invalid event status, and other exceptions in the event status update process.
- Refined error responses for consistent and detailed feedback to the client.