### PR TITLE
feat(events): add functionality to sell tickets and update tickets sold

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/common/exception/InsufficientTicketsException.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/common/exception/InsufficientTicketsException.java
@@ -1,0 +1,14 @@
+package com.sportsevent.sportseventmanager.common.exception;
+
+public class InsufficientTicketsException extends Exception {
+    private final int errorCode;
+
+    public InsufficientTicketsException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
@@ -43,4 +43,8 @@ public class EventRepository {
     public void updateStatusEvent(int eventId, String status) {
         eventDAO.updateStatusEvent(eventId, status);
     }
+
+    public void updateTicketsSold(int eventId, int ticketsSold) {
+        eventDAO.updateTicketsSold(eventId, ticketsSold);
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
@@ -6,6 +6,7 @@ import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
 import com.sportsevent.sportseventmanager.events.dto.AddTeamToEventDTO;
 import com.sportsevent.sportseventmanager.events.dto.EventDTO;
 import com.sportsevent.sportseventmanager.events.dto.EventWithTeamDTO;
+import com.sportsevent.sportseventmanager.events.dto.SellEventTicketDTO;
 import com.sportsevent.sportseventmanager.events.model.Event;
 import com.sportsevent.sportseventmanager.teams.TeamService;
 import com.sportsevent.sportseventmanager.teams.model.Team;
@@ -128,6 +129,28 @@ public class EventService {
 
         return new SuccessResponse(
                 "event status updated successfully",
+                200,
+                event
+        );
+    }
+
+    public SuccessResponse sellTickets(int eventId, SellEventTicketDTO sellEventTicketDTO) throws EventNotFoundException, InsufficientTicketsException {
+        Event event = eventRepository.getEventById(eventId);
+
+        if (event == null) {
+            throw new EventNotFoundException("event not found", 404);
+        }
+
+        int availableTickets = event.getCapacity() - event.getTicketsSold();
+
+        if (sellEventTicketDTO.getQuantity() > availableTickets) {
+            throw new InsufficientTicketsException("not enough tickets available", 409);
+        }
+
+        eventRepository.updateTicketsSold(eventId, event.getTicketsSold() + sellEventTicketDTO.getQuantity());
+
+        return new SuccessResponse(
+                "tickets sold succesfully",
                 200,
                 event
         );

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
@@ -71,4 +71,12 @@ public class EventDAO {
         }
         return false;
     }
+
+    public void updateTicketsSold(int eventId, int ticketsSold) {
+        Event event = getEventById(eventId);
+
+        if (event != null) {
+            event.setTicketsSold(ticketsSold);
+        }
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dto/SellEventTicketDTO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dto/SellEventTicketDTO.java
@@ -1,0 +1,31 @@
+package com.sportsevent.sportseventmanager.events.dto;
+
+import com.sportsevent.sportseventmanager.common.exception.InvalidDTOException;
+import com.sportsevent.sportseventmanager.common.validation.Validatable;
+
+public class SellEventTicketDTO implements Validatable {
+    private Integer quantity;
+
+    public SellEventTicketDTO(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    @Override
+    public void validate() throws InvalidDTOException {
+        if (quantity == null) {
+            throw new InvalidDTOException("quantity is required", 400);
+        }
+
+        if (quantity <= 0) {
+            throw new InvalidDTOException("quantity must be greater than 0", 400);
+        }
+    }
+}


### PR DESCRIPTION
- Added `updateTicketsSold` method to EventRepository to update the number of tickets sold.
- Implemented `sellTickets` method in EventService to handle the selling of tickets for an event.
- Updated EventServlet to handle the `/sell-ticket` endpoint and process ticket sales.
- Introduced `SellEventTicketDTO` to receive the quantity of tickets to be sold in the request.
- Added error handling for insufficient tickets and event not found exceptions.
- Updated EventDAO to support updating the tickets sold in the database.