### PR TITLE
feat(statistics): add event and team statistics functionality

### DIFF
--- a/src/main/java/com/sportsevent/sportseventmanager/config/ServiceConfig.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/config/ServiceConfig.java
@@ -6,6 +6,7 @@ import com.sportsevent.sportseventmanager.events.dao.EventDAO;
 import com.sportsevent.sportseventmanager.players.PlayerRepository;
 import com.sportsevent.sportseventmanager.players.PlayerService;
 import com.sportsevent.sportseventmanager.players.dao.PlayerDAO;
+import com.sportsevent.sportseventmanager.statistics.StatisticService;
 import com.sportsevent.sportseventmanager.teams.TeamRepository;
 import com.sportsevent.sportseventmanager.teams.TeamService;
 import com.sportsevent.sportseventmanager.teams.dao.TeamDAO;
@@ -20,6 +21,7 @@ public class ServiceConfig {
     private static PlayerService playerService;
     private static TeamService teamService;
     private static EventService eventService;
+    private static StatisticService statisticService;
 
     static {
         playerDAO = new PlayerDAO();
@@ -33,6 +35,7 @@ public class ServiceConfig {
         teamService = new TeamService(teamRepository);
         playerService = new PlayerService(playerRepository, teamService);
         eventService = new EventService(eventRepository, teamService);
+        statisticService = new StatisticService(playerService, teamService, eventService);
     }
 
     public static PlayerService getPlayerService() {
@@ -45,6 +48,10 @@ public class ServiceConfig {
 
     public static EventService getEventService() {
         return eventService;
+    }
+
+    public static StatisticService getStatisticService() {
+        return statisticService;
     }
 
     public static PlayerDAO getPlayerDAO() {

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventRepository.java
@@ -43,4 +43,8 @@ public class EventRepository {
     public void updateStatusEvent(int eventId, String status) {
         eventDAO.updateStatusEvent(eventId, status);
     }
+
+    public List<Event> getAllEvents() {
+        return eventDAO.getAllEvents();
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/EventService.java
@@ -11,7 +11,9 @@ import com.sportsevent.sportseventmanager.teams.TeamService;
 import com.sportsevent.sportseventmanager.teams.model.Team;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class EventService {
@@ -131,5 +133,47 @@ public class EventService {
                 200,
                 event
         );
+    }
+
+    public Map<String, Long> countEventsBySport() {
+        List<Event> events = eventRepository.getAllEvents();
+
+        Map<String, Long> eventCountBySport = events.stream().collect(Collectors.groupingBy(Event::getSport, Collectors.counting()));
+
+        return eventCountBySport;
+    }
+
+    public Map<Integer, Long> getTeamsWithMostEvents() {
+        List<Event> events = eventRepository.getAllEvents();
+
+        Map<Integer, Long> teamEventCount = events.stream().flatMap(event -> event.getParticipatingTeams().stream()).collect(Collectors.groupingBy(teamId -> teamId, Collectors.counting()));
+
+        return teamEventCount.entrySet().stream()
+                .sorted(Map.Entry.<Integer, Long>comparingByValue().reversed())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (e1, e2) -> e1,
+                        LinkedHashMap::new
+                ));
+    }
+
+    public Map<Integer, Double> getOccupancyPercentages() {
+        List<Event> events = eventRepository.getAllEvents();
+
+        return events.stream().collect(Collectors.toMap(
+                Event::getId,
+                event -> {
+                    int capacity = event.getCapacity();
+                    int ticketsSold = event.getTicketsSold();
+
+                    double occupancyPercentage = 0.0;
+                    if (capacity > 0) {
+                        occupancyPercentage = (double) ticketsSold / capacity * 100;
+                    }
+
+                    return occupancyPercentage;
+                }
+        ));
     }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/events/dao/EventDAO.java
@@ -71,4 +71,8 @@ public class EventDAO {
         }
         return false;
     }
+
+    public List<Event> getAllEvents() {
+        return events;
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/statistics/StatisticService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/statistics/StatisticService.java
@@ -1,0 +1,36 @@
+package com.sportsevent.sportseventmanager.statistics;
+
+import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
+import com.sportsevent.sportseventmanager.events.EventService;
+import com.sportsevent.sportseventmanager.players.PlayerService;
+import com.sportsevent.sportseventmanager.teams.TeamService;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class StatisticService {
+    PlayerService playerService;
+    TeamService teamService;
+    EventService eventService;
+
+    public StatisticService(PlayerService playerService, TeamService teamService, EventService eventService) {
+        this.playerService = playerService;
+        this.teamService = teamService;
+        this.eventService = eventService;
+    }
+
+    public SuccessResponse getStatistics() {
+        double averagePlayersPerTeam = teamService.getAveragePlayersPerTeam();
+        Map<String, Long> eventsBySport = eventService.countEventsBySport();
+        Map<Integer, Long> teamsWithMostEvents = eventService.getTeamsWithMostEvents();
+        Map<Integer, Double> occupancyPercentages = eventService.getOccupancyPercentages();
+
+        Map<String, Object> statistics = new LinkedHashMap<>();
+        statistics.put("averagePlayersPerTeam", averagePlayersPerTeam);
+        statistics.put("eventsBySport", eventsBySport);
+        statistics.put("teamsWithMostEvents", teamsWithMostEvents);
+        statistics.put("occupancyPercentages", occupancyPercentages);
+
+        return new SuccessResponse("Statistics retrieved successfully", 200, statistics);
+    }
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/statistics/StatisticServlet.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/statistics/StatisticServlet.java
@@ -1,0 +1,57 @@
+package com.sportsevent.sportseventmanager.statistics;
+
+import com.google.gson.Gson;
+import com.sportsevent.sportseventmanager.common.response.ErrorResponse;
+import com.sportsevent.sportseventmanager.common.response.SuccessResponse;
+import com.sportsevent.sportseventmanager.common.utils.GsonProvider;
+import com.sportsevent.sportseventmanager.config.ServiceConfig;
+import com.sportsevent.sportseventmanager.events.EventService;
+import com.sportsevent.sportseventmanager.players.PlayerService;
+import com.sportsevent.sportseventmanager.teams.TeamService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet(name = "StatisticServlet", urlPatterns = "/statistics")
+public class StatisticServlet extends HttpServlet {
+    PlayerService playerService;
+    TeamService teamService;
+    EventService eventService;
+    StatisticService statisticService;
+    Gson gson;
+
+    @Override
+    public void init() throws ServletException {
+        playerService = ServiceConfig.getPlayerService();
+        teamService = ServiceConfig.getTeamService();
+        eventService = ServiceConfig.getEventService();
+        statisticService = ServiceConfig.getStatisticService();
+
+        gson = GsonProvider.createGson();
+    }
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            SuccessResponse successResponse = statisticService.getStatistics();
+
+            String jsonSuccessResponse = gson.toJson(successResponse);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonSuccessResponse);
+        } catch (Exception e) {
+            ErrorResponse errorResponse = new ErrorResponse(e.getMessage(), 500);
+            String jsonErrorResponse = gson.toJson(errorResponse);
+
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.setContentType("application/json");
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().write(jsonErrorResponse);
+        }
+    }
+
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/statistics/dto/StatisticDTO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/statistics/dto/StatisticDTO.java
@@ -1,0 +1,4 @@
+package com.sportsevent.sportseventmanager.statistics.dto;
+
+public class StatisticDTO {
+}

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamRepository.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamRepository.java
@@ -35,4 +35,8 @@ public class TeamRepository {
     public void addPlayerToTeam(int teamId, int playerId) {
         teamDAO.addPlayerToTeam(teamId, playerId);
     }
+
+    public List<Team> getAllTeams() {
+        return teamDAO.getAllTeams();
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/TeamService.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/TeamService.java
@@ -110,4 +110,16 @@ public class TeamService {
 
         return team;
     }
+
+    public double getAveragePlayersPerTeam() {
+        List<Team> teams = teamRepository.getAllTeams();
+
+        if (teams.isEmpty()) {
+            return 0.0;
+        }
+
+        int totalPlayers = teams.stream().mapToInt(team -> team.getPlayers().size()).sum();
+
+        return (double) totalPlayers / teams.size();
+    }
 }

--- a/src/main/java/com/sportsevent/sportseventmanager/teams/dao/TeamDAO.java
+++ b/src/main/java/com/sportsevent/sportseventmanager/teams/dao/TeamDAO.java
@@ -56,4 +56,8 @@ public class TeamDAO {
             }
         }
     }
+
+    public List<Team> getAllTeams() {
+        return teams;
+    }
 }


### PR DESCRIPTION
- Added new methods to `EventService` for generating statistics:
  - `countEventsBySport`: Counts the number of events per sport.
  - `getTeamsWithMostEvents`: Returns teams with the most events.
  - `getOccupancyPercentages`: Calculates event occupancy percentages.
- Introduced `StatisticService` to manage statistics logic.
- Added `getAllEvents` method to `EventRepository` and `EventDAO` to retrieve all events.
- Added `getAveragePlayersPerTeam` method to `TeamService` to calculate the average number of players per team.
- Added `getAllTeams` method to `TeamRepository` and `TeamDAO` to retrieve all teams.
- Updated `ServiceConfig` to include `StatisticService`.